### PR TITLE
requirements dev and requirements.txt is need to be installed separately

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,3 @@
--r requirements.txt
-
 # Automated checks related
 pip
 pre-commit


### PR DESCRIPTION
Installing requirements_dev.txt fails because it pulls in requirements.txt thus mixing hashed dependenciers with non-hashed ones.

Ref: #70 

<a href="https://gitpod.io/#https://github.com/Xcov19/covidX/pull/71"><img src="https://gitpod.io/api/apps/github/pbs/github.com/marcelloromani/covidX.git/35319d90a34d37e4f131e2dffe5970ff3ee9b131.svg" /></a>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcov19/covidx/71)
<!-- Reviewable:end -->
