### PR TITLE
Fix errors detected by DeepSource 

### DIFF
--- a/apps/auth_zero/auth0backend.py
+++ b/apps/auth_zero/auth0backend.py
@@ -127,8 +127,8 @@ class Auth0CodeFlow(Auth0):
             token: str, access token.
             **options: dict, jwt decode options.
         Returns:
-            dict: The dict representation of the claims set, assuming the signature is valid
-                and all requested data validation passes.
+            dict: The dict representation of the claims set, assuming the
+            signature is valid and all requested data validation passes.
         Raises:
             JWTError: If the signature is invalid in any way.
             ExpiredSignatureError: If the signature has expired.

--- a/apps/auth_zero/models.py
+++ b/apps/auth_zero/models.py
@@ -47,7 +47,6 @@ class User(AbstractUser):
     def save(self, *args, **kwargs):
         """Set user type then save."""
         acc_levels: List[UserTypes_T] = []
-        acc_type_ids: List[int]
         if self.username != "AnonymousUser":
             # Refer to auth0backend.Auth0.process_roles to see why
             if self.is_staff:

--- a/covidX/settings/dev.py
+++ b/covidX/settings/dev.py
@@ -1,4 +1,4 @@
-# pylint:disable=E0611
+# pylint:disable=E0611 skipcq: PYL-W0614
 from covidX.settings.base import *
 
 CONFIG_FILE = "apps/auth_zero/config/test_config.ini"


### PR DESCRIPTION
Fixes problems with code detected by DeepSource

This will make reviewing pull requests easier, as now, errors arising from parts of the repository that remained unchanged after the pull request will not cause the `DeepSource: Python` check to fail for every pull request. Hence, it will be clear whether it is actually the pull request causing the check to fail or not.

<a href="https://gitpod.io/#https://github.com/Xcov19/covidX/pull/123"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcov19/covidx/123)
<!-- Reviewable:end -->
