### PR TITLE
Remove __init__.py in root of repository

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -29,11 +29,6 @@ DEPS = [
     "//covidX:wsgi",
 ] + [requirement(r) for r in REQS]
 
-py_library(
-    name = "__init__",
-    srcs = ["__init__.py"],
-)
-
 py_binary(
     name = "manage",
     srcs=["manage.py"],

--- a/covidX/BUILD
+++ b/covidX/BUILD
@@ -19,6 +19,9 @@ py_library(
         "//covidX/settings:base",
         "//covidX/settings:dev",
     ],
+    deps = [
+        "//covidX/settings:__init__"
+    ],
     srcs_version="PY3",
     data = ["//:static",],
 )

--- a/covidX/BUILD
+++ b/covidX/BUILD
@@ -20,7 +20,7 @@ py_library(
         "//covidX/settings:dev",
     ],
     deps = [
-        "//covidX:__init__"
+        "//covidX:__init__",
     ],
     srcs_version="PY3",
     data = ["//:static",],

--- a/covidX/BUILD
+++ b/covidX/BUILD
@@ -20,7 +20,7 @@ py_library(
         "//covidX/settings:dev",
     ],
     deps = [
-        "//covidX/settings:__init__"
+        "//covidX:__init__"
     ],
     srcs_version="PY3",
     data = ["//:static",],

--- a/covidX/BUILD
+++ b/covidX/BUILD
@@ -19,9 +19,6 @@ py_library(
         "//covidX/settings:base",
         "//covidX/settings:dev",
     ],
-    deps = [
-        "//:__init__",
-    ],
     srcs_version="PY3",
     data = ["//:static",],
 )

--- a/covidX/settings/BUILD
+++ b/covidX/settings/BUILD
@@ -30,6 +30,7 @@ py_library(
         "//apps/auth_zero:apps",
         "//apps/auth_zero:models",
         "//apps/auth_zero:auth0backend",
+        "//covidX/settings:__init__"
     ],
     srcs_version="PY3",
     data = ["//:static",],

--- a/covidX/settings/BUILD
+++ b/covidX/settings/BUILD
@@ -30,7 +30,7 @@ py_library(
         "//apps/auth_zero:apps",
         "//apps/auth_zero:models",
         "//apps/auth_zero:auth0backend",
-        "//covidX/settings:__init__"
+        "//covidX/settings:__init__",
     ],
     srcs_version="PY3",
     data = ["//:static",],

--- a/covidX/settings/BUILD
+++ b/covidX/settings/BUILD
@@ -30,7 +30,6 @@ py_library(
         "//apps/auth_zero:apps",
         "//apps/auth_zero:models",
         "//apps/auth_zero:auth0backend",
-        "//:__init__",
     ],
     srcs_version="PY3",
     data = ["//:static",],


### PR DESCRIPTION
Removes `__init__.py` in the root of the repository to allow tests to be found by `unittest` (see [Running django tutorial tests fail - No module named polls.tests](https://stackoverflow.com/questions/21069880/running-django-tutorial-tests-fail-no-module-named-polls-tests))

This also makes sense intuitively. Since `__init__.py` files mark directories as Python packages, it does not make sense for the root directory to have an `__init__.py` file as it should never be referenced as a package.

<a href="https://gitpod.io/#https://github.com/Xcov19/covidX/pull/124"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcov19/covidx/124)
<!-- Reviewable:end -->
