### PR TITLE
Upgrade graphene-django version to fix security vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,9 +26,7 @@ aniso8601==7.0.0 \
 appnope==0.1.2 \
     --hash=sha256:93aa393e9d6c54c5cd570ccadd8edad61ea0c4b9ea7a01409020c9aa019eb442 \
     --hash=sha256:dd83cd4b5b460958838f6eb3000c660b1f9caf2a5b1de4264e941512f603258a
-    # via
-    #   -r requirements.txt
-    #   ipython
+    # via -r requirements.txt
 asgiref==3.2.10 \
     --hash=sha256:7e51911ee147dd685c3c8b805c0ad0cb58d360987b56953878f8c06d2d1c6f1a \
     --hash=sha256:9fc6fb5d39b8af147ba40765234fa822b39818b12cc80b35ad9b0cef3a476aed
@@ -259,7 +257,7 @@ googleapis-common-protos[grpc]==1.53.0 \
     #   -r requirements.txt
     #   google-api-core
     #   grpc-google-iam-v1
-graphene-django==2.13.0 \
+graphene-django==2.15.0 \
     --hash=sha256:0e33cdec0774284175c387c2af1e0ef4eb0f4e10a56a3a1b2d39bc3a74d9a538 \
     --hash=sha256:8a4efc7bf954ba0b5a28d3cdb090b36941aca6b83d211e3cd3ab29cf53ac6154
     # via -r requirements.txt
@@ -738,6 +736,7 @@ text-unidecode==1.3 \
     # via
     #   -r requirements.txt
     #   faker
+    #   graphene-django
 toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
@@ -768,9 +767,7 @@ typing-inspect==0.6.0 \
 unidecode==1.1.1 \
     --hash=sha256:1d7a042116536098d05d599ef2b8616759f02985c85b4fef50c78a5aaf10822a \
     --hash=sha256:2b6aab710c2a1647e928e36d69c21e76b453cd455f4e2621000e54b2a9b8cce8
-    # via
-    #   -r requirements.txt
-    #   graphene-django
+    # via -r requirements.txt
 uritemplate==3.0.1 \
     --hash=sha256:07620c3f3f8eed1f12600845892b0e036a2420acf513c53f7de0abd911a5894f \
     --hash=sha256:5af8ad10cec94f215e3f48112de2022e1d5a37ed427fbd88652fa908f2ab7cae
@@ -810,5 +807,3 @@ xlrd==1.2.0 \
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
 # setuptools
-setuptools==56.0.0 \
-    --hash=sha256:7430499900e443375ba9449a9cc5d78506b801e929fef4a186496012f93683b5

--- a/requirements.txt
+++ b/requirements.txt
@@ -807,3 +807,5 @@ xlrd==1.2.0 \
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
 # setuptools
+setuptools==56.0.0 \
+    --hash=sha256:7430499900e443375ba9449a9cc5d78506b801e929fef4a186496012f93683b5


### PR DESCRIPTION
Update graphene-django version for Issue - CVE-2021-3281 - Medium Severity Vulnerability

<a href="https://gitpod.io/#https://github.com/Xcov19/covidX/pull/125"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcov19/covidx/125)
<!-- Reviewable:end -->
